### PR TITLE
Elemento "Header" debería ser multi-word

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,28 +1,18 @@
 <template>
-  <img alt="Vue logo" src="./assets/logo.png" />
-  <HelloWorld msg="Welcome to Your Vue.js App" />
   <MainHeader />
 </template>
 
-<script>
-import HelloWorld from "./components/HelloWorld.vue";
-
-export default {
-  name: "App",
-  components: {
-    HelloWorld,
-    MainHeader: () => import("./components/MainHeader.vue"),
-  },
-};
+<script setup>
+import MainHeader from "./components/MainHeader.vue";
 </script>
 
 <style>
+@import url(assets/base.css);
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
-  margin-top: 60px;
 }
 </style>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,19 +1,19 @@
 <template>
-  <img alt="Vue logo" src="./assets/logo.png">
-  <HelloWorld msg="Welcome to Your Vue.js App"/>
-  <Header/>
+  <img alt="Vue logo" src="./assets/logo.png" />
+  <HelloWorld msg="Welcome to Your Vue.js App" />
+  <MainHeader />
 </template>
 
 <script>
-import HelloWorld from './components/HelloWorld.vue'
+import HelloWorld from "./components/HelloWorld.vue";
 
 export default {
-  name: 'App',
+  name: "App",
   components: {
     HelloWorld,
-    Header: () => import('./components/Header.vue') 
-  }
-}
+    MainHeader: () => import("./components/MainHeader.vue"),
+  },
+};
 </script>
 
 <style>

--- a/web/src/assets/base.css
+++ b/web/src/assets/base.css
@@ -1,0 +1,4 @@
+* {
+  margin: 0;
+  padding: 0;
+}

--- a/web/src/components/MainHeader.vue
+++ b/web/src/components/MainHeader.vue
@@ -13,7 +13,7 @@
 
 <script setup>
 import { ref } from "vue";
-import GrowingLine from "./GrowingLine.vue";
+
 let headerItems = ref([
   { href: "/", text: "Inicio" },
   { href: "/about", text: "Quiénes somos" },

--- a/web/src/components/MainHeader.vue
+++ b/web/src/components/MainHeader.vue
@@ -1,7 +1,7 @@
 <template>
-  <header>
+  <div class="main-header">
     <h1>VIII Jornadas Ingenieros en la UPO</h1>
-    <nav>
+    <nav class="main-header--navbar">
       <ul>
         <li><a href="/">Inicio</a></li>
         <li><a href="/about">Quiénes somos</a></li>
@@ -19,33 +19,29 @@
         <li><a href="/contact">Contact</a></li>
       </ul>
     </nav>
-  </header>
+  </div>
 </template>
 
-<script>
-export default {
-  name: "mainHeader",
-};
-</script>
+<script setup></script>
 
 <style scoped>
-header {
+.main-header {
   background-color: #f0f0f0;
   padding: 20px;
   text-align: center;
 }
 
-nav ul {
+.main-header--navbar ul {
   list-style: none;
   padding: 0;
 }
 
-nav li {
+.main-header--navbar li {
   display: inline;
   margin: 0 10px;
 }
 
-nav a {
+.main-header--navbar a {
   text-decoration: none;
   color: #333;
 }

--- a/web/src/components/MainHeader.vue
+++ b/web/src/components/MainHeader.vue
@@ -1,4 +1,3 @@
-vue
 <template>
   <header>
     <h1>VIII Jornadas Ingenieros en la UPO</h1>
@@ -9,10 +8,14 @@ vue
         <li><a href="/ingenierosUpo">¿Qué es el Ingenieros en la UPO?</a></li>
         <li><a href="/entradas">Sobre las entradas</a></li>
         <li><a href="/evento">¿En qué consiste el evento?</a></li>
-        <li><a href="/organizadoresYapoyo">Organizadores y Apoyo Institucional</a></li>
+        <li>
+          <a href="/organizadoresYapoyo">Organizadores y Apoyo Institucional</a>
+        </li>
         <li><a href="/impacto">Nuestro Impacto</a></li>
         <li><a href="/patrocinios">Patrocinadores</a></li>
-        <li><a href="inversionPatrocinio">¿En qué invertiremos el patrocinio?</a></li>
+        <li>
+          <a href="inversionPatrocinio">¿En qué invertiremos el patrocinio?</a>
+        </li>
         <li><a href="/contact">Contact</a></li>
       </ul>
     </nav>
@@ -21,8 +24,8 @@ vue
 
 <script>
 export default {
-  name: 'Header'
-}
+  name: "mainHeader",
+};
 </script>
 
 <style scoped>

--- a/web/src/components/MainHeader.vue
+++ b/web/src/components/MainHeader.vue
@@ -3,26 +3,30 @@
     <h1>VIII Jornadas Ingenieros en la UPO</h1>
     <nav class="main-header--navbar">
       <ul>
-        <li><a href="/">Inicio</a></li>
-        <li><a href="/about">Quiénes somos</a></li>
-        <li><a href="/ingenierosUpo">¿Qué es el Ingenieros en la UPO?</a></li>
-        <li><a href="/entradas">Sobre las entradas</a></li>
-        <li><a href="/evento">¿En qué consiste el evento?</a></li>
-        <li>
-          <a href="/organizadoresYapoyo">Organizadores y Apoyo Institucional</a>
+        <li v-for="item in headerItems" :key="item.href">
+          <a :href="item.href">{{ item.text }}</a>
         </li>
-        <li><a href="/impacto">Nuestro Impacto</a></li>
-        <li><a href="/patrocinios">Patrocinadores</a></li>
-        <li>
-          <a href="inversionPatrocinio">¿En qué invertiremos el patrocinio?</a>
-        </li>
-        <li><a href="/contact">Contact</a></li>
       </ul>
     </nav>
   </div>
 </template>
 
-<script setup></script>
+<script setup>
+import { ref } from "vue";
+import GrowingLine from "./GrowingLine.vue";
+let headerItems = ref([
+  { href: "/", text: "Inicio" },
+  { href: "/about", text: "Quiénes somos" },
+  { href: "/ingenierosUpo", text: "¿Qué es el Ingenieros en la UPO?" },
+  { href: "/entradas", text: "Sobre las entradas" },
+  { href: "/evento", text: "¿En qué consiste el evento?" },
+  { href: "/organizadoresYapoyo", text: "Organizadores y Apoyo Institucional" },
+  { href: "/impacto", text: "Nuestro Impacto" },
+  { href: "/patrocinios", text: "Patrocinadores" },
+  { href: "/inversionPatrocinio", text: "¿En qué invertiremos el patrocinio?" },
+  { href: "/contact", text: "Contact" },
+]);
+</script>
 
 <style scoped>
 .main-header {
@@ -31,13 +35,19 @@
   text-align: center;
 }
 
+.main-header--navbar {
+  margin-top: 20px;
+}
+
 .main-header--navbar ul {
+  display: flex;
   list-style: none;
   padding: 0;
 }
 
 .main-header--navbar li {
   display: inline;
+  padding: 3px;
   margin: 0 10px;
 }
 


### PR DESCRIPTION
# Descripción
En Vue, los elementos creados por el usuario deben ser _multi-word_, es decir, ser del estilo "MainHeader", "NavHeader", etc, para que a la hora de importarlo, no se confunda el tag html "header" con el componente "header".

![imagen](https://github.com/user-attachments/assets/2ca3c289-f378-4415-8449-89fd1686a74f)

# Solución
Se ha renombrado el componente "Header" a "MainHeader".

Además, se le ha cambiado el <script> a <script setup>, para poder hacer uso del _composition API_ de vue, que es al fin y al cabo lo más característico y potente del framework.

También se han hecho cambios en el css y en algunas estructuras del header.